### PR TITLE
Accept text without position

### DIFF
--- a/svgtoipe/svgtoipe.py
+++ b/svgtoipe/svgtoipe.py
@@ -705,11 +705,16 @@ class Svg():
         self.collect_text(n)
 
   def node_text(self, t):
-    if not t.hasAttribute("x") or not t.hasAttribute("y"):
-      sys.stderr.write("Text without coordinates ignored\n")
-      return
-    x = float(t.getAttribute("x"))
-    y = float(t.getAttribute("y"))
+    if not t.hasAttribute("x"):
+        x = 0.0
+    else:
+        x = float(t.getAttribute("x"))
+
+    if not t.hasAttribute("y"):
+        y = 0.0
+    else:
+        y = float(t.getAttribute("y"))
+    
     attr = self.parse_attributes(t)
     self.out.write('<text pos="%g %g"' % (x,y))
     self.out.write(' transformations="affine" valign="baseline"')


### PR DESCRIPTION
According to the SVG specification[0], the "x" and "y" attributes of text elements are not mandatory. If they are missing, they must be assumed to be "0". Currently, svgtoipe ignores such text elements.

Kind regards,

Lukas

[0] https://www.w3.org/TR/SVG/text.html#TextElementXAttribute