### PR TITLE
Fix handling of path opcode 'z'

### DIFF
--- a/svgtoipe/svgtoipe.py
+++ b/svgtoipe/svgtoipe.py
@@ -161,17 +161,20 @@ def parse_path(out, d):
   d = re.findall("([A-Za-z]|-?[0-9]+\.?[0-9]*(?:e-?[0-9]*)?)", d)
   x, y = 0.0, 0.0
   xs, ys = 0.0, 0.0
+  x0, y0 = 0.0, 0.0
   while d:
     if not d[0][0] in "01234567890.-":
       opcode = d.pop(0)
     if opcode == 'M':
       x, y = pnext(d, 2)
+      x0, y0 = x, y
       out.write("%g %g m\n" % (x, y))
       opcode = 'L'
     elif opcode == 'm':
       x1, y1 = pnext(d, 2)
       x += x1
       y += y1
+      x0, y0 = x, y
       out.write("%g %g m\n" % (x, y))
       opcode = 'l'
     elif opcode == 'L':
@@ -235,6 +238,7 @@ def parse_path(out, d):
       draw_arc(out, x, y, rx, ry, phi, large_arc, sweep, x2, y2)
       x, y = x2, y2
     elif opcode in 'zZ':
+      x, y = x0, y0
       out.write("h\n")
     else:
       sys.stderr.write("Unrecognised opcode: %s\n" % opcode)


### PR DESCRIPTION
When 'z' is found, the "current position" should be updated to the first vertex of the path.

Minimal example (renders as a square minus a triangle):

```
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<svg xmlns="http://www.w3.org/2000/svg" width="1mm" height="1mm" viewBox="0 0 1 1" version="1.1">
<path d="m 0,0 0,1 1,0 0,-1 z m 0.1,0.1 0.8,0 -0.4,0.8 z" />
</svg>
```

Incorrect output:

```
<path>
0 0 m
0 1 l
1 1 l
1 0 l
h
1.1 0.1 m
1.9 0.1 l
1.5 0.9 l
h
</path>
```

Correct output:

```
<path>
0 0 m
0 1 l
1 1 l
1 0 l
h
0.1 0.1 m
0.9 0.1 l
0.5 0.9 l
h
</path>
```