### PR TITLE
replace deprecated poppler boolean types

### DIFF
--- a/pdftoipe/parseargs.cc
+++ b/pdftoipe/parseargs.cc
@@ -32,14 +32,14 @@
 /* #include "goo/gstrtod.h" */
 
 static const ArgDesc *findArg(const ArgDesc *args, char *arg);
-static GBool grabArg(const ArgDesc *arg, int i, int *argc, char *argv[]);
+static bool grabArg(const ArgDesc *arg, int i, int *argc, char *argv[]);
 
-GBool parseArgs(const ArgDesc *args, int *argc, char *argv[]) {
+bool parseArgs(const ArgDesc *args, int *argc, char *argv[]) {
   const ArgDesc *arg;
   int i, j;
-  GBool ok;
+  bool ok;
 
-  ok = gTrue;
+  ok = true;
   i = 1;
   while (i < *argc) {
     if (!strcmp(argv[i], "--")) {
@@ -49,7 +49,7 @@ GBool parseArgs(const ArgDesc *args, int *argc, char *argv[]) {
       break;
     } else if ((arg = findArg(args, argv[i]))) {
       if (!grabArg(arg, i, argc, argv))
-	ok = gFalse;
+	ok = false;
     } else {
       ++i;
     }
@@ -112,16 +112,16 @@ static const ArgDesc *findArg(const ArgDesc *args, char *arg) {
   return NULL;
 }
 
-static GBool grabArg(const ArgDesc *arg, int i, int *argc, char *argv[]) {
+static bool grabArg(const ArgDesc *arg, int i, int *argc, char *argv[]) {
   int n;
   int j;
-  GBool ok;
+  bool ok;
 
-  ok = gTrue;
+  ok = true;
   n = 0;
   switch (arg->kind) {
   case argFlag:
-    *(GBool *)arg->val = gTrue;
+    *(bool *)arg->val = true;
     n = 1;
     break;
   case argInt:
@@ -129,7 +129,7 @@ static GBool grabArg(const ArgDesc *arg, int i, int *argc, char *argv[]) {
       *(int *)arg->val = atoi(argv[i+1]);
       n = 2;
     } else {
-      ok = gFalse;
+      ok = false;
       n = 1;
     }
     break;
@@ -138,7 +138,7 @@ static GBool grabArg(const ArgDesc *arg, int i, int *argc, char *argv[]) {
       *(double *)arg->val = atof(argv[i+1]);
       n = 2;
     } else {
-      ok = gFalse;
+      ok = false;
       n = 1;
     }
     break;
@@ -148,7 +148,7 @@ static GBool grabArg(const ArgDesc *arg, int i, int *argc, char *argv[]) {
       ((char *)arg->val)[arg->size - 1] = '\0';
       n = 2;
     } else {
-      ok = gFalse;
+      ok = false;
       n = 1;
     }
     break;
@@ -165,17 +165,17 @@ static GBool grabArg(const ArgDesc *arg, int i, int *argc, char *argv[]) {
   return ok;
 }
 
-GBool isInt(char *s) {
+bool isInt(char *s) {
   if (*s == '-' || *s == '+')
     ++s;
   while (isdigit(*s))
     ++s;
   if (*s)
-    return gFalse;
-  return gTrue;
+    return false;
+  return true;
 }
 
-GBool isFP(char *s) {
+bool isFP(char *s) {
   int n;
 
   if (*s == '-' || *s == '+')
@@ -197,12 +197,12 @@ GBool isFP(char *s) {
       ++s;
     n = 0;
     if (!isdigit(*s))
-      return gFalse;
+      return false;
     do {
       ++s;
     } while (isdigit(*s));
   }
   if (*s)
-    return gFalse;
-  return gTrue;
+    return false;
+  return true;
 }

--- a/pdftoipe/parseargs.h
+++ b/pdftoipe/parseargs.h
@@ -34,7 +34,7 @@ extern "C" {
  */
 typedef enum {
   argFlag,			/* flag (present / not-present) */
-				/*   [val: GBool *]             */
+				/*   [val: bool *]             */
   argInt,			/* integer arg    */
 				/*   [val: int *] */
   argFP,			/* floating point arg */
@@ -65,7 +65,7 @@ typedef struct {
  * descriptor list <args>.  Stops parsing if "--" is found (and removes
  * it).  Returns gFalse if there was an error.
  */
-extern GBool parseArgs(const ArgDesc *args, int *argc, char *argv[]);
+extern bool parseArgs(const ArgDesc *args, int *argc, char *argv[]);
 
 /*
  * Print usage message, based on arg descriptor list.
@@ -75,8 +75,8 @@ extern void printUsage(char *program, char *otherArgs, const ArgDesc *args);
 /*
  * Check if a string is a valid integer or floating point number.
  */
-extern GBool isInt(char *s);
-extern GBool isFP(char *s);
+extern bool isInt(char *s);
+extern bool isFP(char *s);
 
 #ifdef __cplusplus
 }

--- a/pdftoipe/pdftoipe.cpp
+++ b/pdftoipe/pdftoipe.cpp
@@ -29,11 +29,11 @@ static int mergeLevel = 0;
 static int unicodeLevel = 1;
 static char ownerPassword[33] = "";
 static char userPassword[33] = "";
-static GBool quiet = gFalse;
-static GBool printHelp = gFalse;
-static GBool math = gFalse;
-static GBool literal = gFalse;
-static GBool notext = gFalse;
+static bool quiet = false;
+static bool printHelp = false;
+static bool math = false;
+static bool literal = false;
+static bool notext = false;
 
 static ArgDesc argDesc[] = {
   {"-f",      argInt,      &firstPage,      0,
@@ -70,7 +70,7 @@ static ArgDesc argDesc[] = {
 int main(int argc, char *argv[])
 {
   // parse args
-  GBool ok = parseArgs(argDesc, &argc, argv);
+  bool ok = parseArgs(argDesc, &argc, argv);
   if (!ok || argc < 2 || argc > 3 || printHelp) {
     fprintf(stderr, "pdftoipe version %s\n", PDFTOIPE_VERSION);
     printUsage("pdftoipe", "<PDF-file> [<XML-file>]", argDesc);
@@ -137,8 +137,8 @@ int main(int argc, char *argv[])
   if (xmlOut->isOk()) {
     doc->displayPages(xmlOut, firstPage, lastPage, 
 		      // double hDPI, double vDPI, int rotate,
-		      // GBool useMediaBox, GBool crop, GBool printing,
-		      72.0, 72.0, 0, gFalse, gFalse, gFalse);
+		      // bool useMediaBox, bool crop, bool printing,
+		      72.0, 72.0, 0, false, false, false);
     exitCode = 0;
   }
 

--- a/pdftoipe/readme.txt
+++ b/pdftoipe/readme.txt
@@ -46,9 +46,9 @@ option) any later version.
 Compiling
 =========
 
-You need the Poppler library (http://poppler.freedesktop.org).  On
-Debian/Ubuntu, install the packages 'libpoppler-dev' and
-'libpoppler-private-dev'. 
+You need the Poppler library (http://poppler.freedesktop.org) v0.71.0
+or greater.  On Debian/Ubuntu, install the packages 'libpoppler-dev'
+and 'libpoppler-private-dev'.
 
 In source directory, say
 

--- a/pdftoipe/xmloutputdev.cpp
+++ b/pdftoipe/xmloutputdev.cpp
@@ -31,13 +31,13 @@ XmlOutputDev::XmlOutputDev(const char *fileName, XRef *xrefA, Catalog *catalog,
 
   if (!(f = fopen(fileName, "wb"))) {
     fprintf(stderr, "Couldn't open output file '%s'\n", fileName);
-    ok = gFalse;
+    ok = false;
     return;
   }
   outputStream = f;
 
   // initialize
-  ok = gTrue;
+  ok = true;
   xref = xrefA;
   inText = false;
   iUnicode = false;
@@ -98,9 +98,9 @@ XmlOutputDev::~XmlOutputDev()
 
 // ----------------------------------------------------------
 
-void XmlOutputDev::setTextHandling(GBool math, GBool notext, 
-				   GBool literal, int mergeLevel,
-				   int unicodeLevel)
+void XmlOutputDev::setTextHandling(bool math, bool notext, 
+                                   bool literal, int mergeLevel,
+                                   int unicodeLevel)
 {
   iIsMath = math;
   iNoText = notext;
@@ -323,9 +323,9 @@ void XmlOutputDev::finishText()
 // --------------------------------------------------------------------
 
 void XmlOutputDev::drawImage(GfxState *state, Object *ref, Stream *str,
-			     int width, int height, GfxImageColorMap *colorMap,
-			     GBool interpolate, int *maskColors, 
-			     GBool inlineImg)
+                             int width, int height, GfxImageColorMap *colorMap,
+                             bool interpolate, int *maskColors, 
+                             bool inlineImg)
 {
   finishText();
 

--- a/pdftoipe/xmloutputdev.h
+++ b/pdftoipe/xmloutputdev.h
@@ -22,31 +22,31 @@ public:
 
   // Open an XML output file, and write the prolog.
   XmlOutputDev(const char *fileName, XRef *xrefA, Catalog *catalog,
-	       int firstPage, int lastPage);
+               int firstPage, int lastPage);
   
   // Destructor -- writes the trailer and closes the file.
   virtual ~XmlOutputDev();
 
   // Check if file was successfully created.
-  virtual GBool isOk() { return ok; }
+  virtual bool isOk() { return ok; }
 
   bool hasUnicode() const { return iUnicode; }
 
-  void setTextHandling(GBool math, GBool notext, GBool literal,
-		       int mergeLevel, int unicodeLevel);
+  void setTextHandling(bool math, bool notext, bool literal,
+                       int mergeLevel, int unicodeLevel);
   
   //---- get info about output device
 
   // Does this device use upside-down coordinates?
   // (Upside-down means (0,0) is the top left corner of the page.)
-  virtual GBool upsideDown() { return gFalse; }
+  virtual bool upsideDown() { return false; }
 
   // Does this device use drawChar() or drawString()?
-  virtual GBool useDrawChar() { return gTrue; }
+  virtual bool useDrawChar() { return true; }
 
   // Does this device use beginType3Char/endType3Char?  Otherwise,
   // text in Type 3 fonts will be drawn with drawChar/drawString.
-  virtual GBool interpretType3Chars() { return gFalse; }
+  virtual bool interpretType3Chars() { return false; }
 
   //----- initialization and control
 
@@ -75,7 +75,7 @@ public:
   //----- image drawing
   virtual void drawImage(GfxState *state, Object *ref, Stream *str,
 			 int width, int height, GfxImageColorMap *colorMap,
-			 GBool interpolate, int *maskColors, GBool inlineImg);
+			 bool interpolate, int *maskColors, bool inlineImg);
 
 protected:
   virtual void startDrawingPath();
@@ -93,7 +93,7 @@ protected:
   FILE *outputStream;
   int seqPage;			// current sequential page number
   XRef *xref;			// the xref table for this PDF file
-  GBool ok;			// set up ok?
+  bool ok;			    // set up ok?
   bool iUnicode;                // has a Unicode character been used?
 
   bool iIsLiteral;              // take latex in text literally


### PR DESCRIPTION
poppler 0.71.0 replaces their own `GBool` / `gTrue` / `gFalse` types with standard c++ booleans.

