### PR TITLE
Fix compilation against poppler 0.72.0

### DIFF
--- a/pdftoipe/pdftoipe.cpp
+++ b/pdftoipe/pdftoipe.cpp
@@ -104,18 +104,18 @@ int main(int argc, char *argv[])
     return 1;
   
   // construct XML file name
-  GooString *xmlFileName;
+  std::string xmlFileName;
   if (argc == 3) {
-    xmlFileName = new GooString(argv[2]);
+    xmlFileName = argv[2];
   } else {
-    const char *p = fileName->getCString() + fileName->getLength() - 4;
+    const char *p = fileName->c_str() + fileName->getLength() - 4;
     if (!strcmp(p, ".pdf") || !strcmp(p, ".PDF")) {
-      xmlFileName = new GooString(fileName->getCString(),
-				  fileName->getLength() - 4);
+        xmlFileName = std::string(fileName->c_str(),
+                                  fileName->getLength() - 4);
     } else {
-      xmlFileName = fileName->copy();
+      xmlFileName = fileName->c_str();
     }
-    xmlFileName->append(".ipe");
+    xmlFileName += ".ipe";
   }
 
   // get page range
@@ -127,8 +127,8 @@ int main(int argc, char *argv[])
 
   // write XML file
   XmlOutputDev *xmlOut = 
-    new XmlOutputDev(xmlFileName->getCString(), doc->getXRef(),
-		     doc->getCatalog(), firstPage, lastPage);
+    new XmlOutputDev(xmlFileName, doc->getXRef(),
+                     doc->getCatalog(), firstPage, lastPage);
 
   // tell output device about text handling
   xmlOut->setTextHandling(math, notext, literal, mergeLevel, unicodeLevel);
@@ -152,7 +152,6 @@ int main(int argc, char *argv[])
 
   // clean up
   delete xmlOut;
-  delete xmlFileName;
   delete doc;
   delete globalParams;
 

--- a/pdftoipe/readme.txt
+++ b/pdftoipe/readme.txt
@@ -46,7 +46,7 @@ option) any later version.
 Compiling
 =========
 
-You need the Poppler library (http://poppler.freedesktop.org) v0.71.0
+You need the Poppler library (http://poppler.freedesktop.org) v0.72.0
 or greater.  On Debian/Ubuntu, install the packages 'libpoppler-dev'
 and 'libpoppler-private-dev'.
 
@@ -55,7 +55,7 @@ In source directory, say
 make
 
 This will create the single executable "pdftoipe".  Copy it to
-whereever you like.  You may also install the man page "pdftoipe.1".
+wherever you like.  You may also install the man page "pdftoipe.1".
 
 If you want to compile pdftoipe on Windows, please refer to
 "compile_on_windows.pdf", written by Daniel Beckmann.
@@ -65,7 +65,12 @@ If you want to compile pdftoipe on Windows, please refer to
 Changes
 =======
 
- * 2018/11/01
+ * 2018/12/07
+   Changes to compile with poppler 0.72.0. GString is now based on
+   std::string and may be gettng deprecated soon so get rid of some
+   uses.
+
+* 2018/11/01
    Poppler keeps changing: gBool -> bool (issue #31).
 
  * 2018/10/23

--- a/pdftoipe/xmloutputdev.cpp
+++ b/pdftoipe/xmloutputdev.cpp
@@ -6,6 +6,8 @@
 #include <stddef.h>
 #include <stdarg.h>
 
+#include <string>
+
 #include "Object.h"
 #include "Error.h"
 #include "Gfx.h"
@@ -24,13 +26,13 @@
 // XmlOutputDev
 //------------------------------------------------------------------------
 
-XmlOutputDev::XmlOutputDev(const char *fileName, XRef *xrefA, Catalog *catalog,
-			   int firstPage, int lastPage)
+XmlOutputDev::XmlOutputDev(const std::string& fileName, XRef *xrefA, Catalog *catalog,
+                           int firstPage, int lastPage)
 {
   FILE *f;
 
-  if (!(f = fopen(fileName, "wb"))) {
-    fprintf(stderr, "Couldn't open output file '%s'\n", fileName);
+  if (!(f = fopen(fileName.c_str(), "wb"))) {
+    fprintf(stderr, "Couldn't open output file '%s'\n", fileName.c_str());
     ok = false;
     return;
   }

--- a/pdftoipe/xmloutputdev.h
+++ b/pdftoipe/xmloutputdev.h
@@ -14,14 +14,14 @@
 class GfxPath;
 class GfxFont;
 
-#define PDFTOIPE_VERSION "2018/11/01"
+#define PDFTOIPE_VERSION "2018/12/07"
 
 class XmlOutputDev : public OutputDev
 {
 public:
 
   // Open an XML output file, and write the prolog.
-  XmlOutputDev(const char *fileName, XRef *xrefA, Catalog *catalog,
+  XmlOutputDev(const std::string& fileName, XRef *xrefA, Catalog *catalog,
                int firstPage, int lastPage);
   
   // Destructor -- writes the trailer and closes the file.


### PR DESCRIPTION
GString implementation is now based on std::string and some methods and constness have changed. Better to avoid using it unless required by poppler classes.