### PR TITLE
Removed use of deprecated is_string_like

### DIFF
--- a/matplotlib/backend_ipe.py
+++ b/matplotlib/backend_ipe.py
@@ -21,6 +21,8 @@ from __future__ import division, print_function, unicode_literals
 
 import os, base64, tempfile, urllib, gzip, io, sys, codecs, re
 
+from six import string_types
+
 import matplotlib
 from matplotlib import rcParams
 from matplotlib._pylab_helpers import Gcf
@@ -28,7 +30,7 @@ from matplotlib.backend_bases import RendererBase, GraphicsContextBase
 from matplotlib.backend_bases import FigureManagerBase, FigureCanvasBase
 from matplotlib.figure import Figure
 from matplotlib.transforms import Bbox
-from matplotlib.cbook import is_string_like, is_writable_file_like, maxdict
+from matplotlib.cbook import is_writable_file_like, maxdict
 from matplotlib.path import Path
 
 from xml.sax.saxutils import escape as escape_xml_text
@@ -458,7 +460,7 @@ class FigureCanvasIpe(FigureCanvasBase):
     filetypes['ipe'] = 'Ipe 7 file format'
 
     def print_ipe(self, filename, *args, **kwargs):
-        if is_string_like(filename):
+        if isinstance(filename, string_types):
             fh_to_close = ipewriter = io.open(filename, 'w', encoding='utf-8')
         elif is_writable_file_like(filename):
             if not isinstance(filename, io.TextIOBase):


### PR DESCRIPTION
For compatibility with matplotlib 3.x
Removed deprecated is_string_like, instead the six library is used for 2.x-and-3.x-compatible code
https://stackoverflow.com/questions/11301138/how-to-check-if-variable-is-string-with-python-2-and-3-compatibility