### PR TITLE
pdftoipe: fix for poppler >= 22.09

### DIFF
--- a/pdftoipe/xmloutputdev.cpp
+++ b/pdftoipe/xmloutputdev.cpp
@@ -149,15 +149,15 @@ void XmlOutputDev::stroke(GfxState *state)
   writeColor("<path stroke=", rgb, 0);
   writePSFmt(" pen=\"%g\"", state->getTransformedLineWidth());
 
-  double *dash;
   double start;
-  int length, i;
+  std::vector<double> dash = state->getLineDash(&start);
+  int length = dash.size();
+  int i;
 
-  state->getLineDash(&dash, &length, &start);
   if (length) {
     writePS(" dash=\"[");
     for (i = 0; i < length; ++i)
-      writePSFmt("%g%s", state->transformWidth(dash[i]), 
+      writePSFmt("%g%s", state->transformWidth(dash.at(i)),
 		 (i == length-1) ? "" : " ");
     writePSFmt("] %g\"", state->transformWidth(start));
   }


### PR DESCRIPTION
Fixes build error:


```
clang++ -Wno-write-strings -std=c++17 -I/opt/homebrew/Cellar/poppler/22.11.0/include/poppler  -c -o pdftoipe.o pdftoipe.cpp
xmloutputdev.cpp:156:29: error: too many arguments to function call, expected single argument 'start', have 3 arguments
state->getLineDash(&dash, &length, &start);
~~~~~~~~~~~~~~~~~~        ^~~~~~~~~~~~~~~
/opt/homebrew/Cellar/poppler/22.11.0/include/poppler/GfxState.h:1506:32: note: 'getLineDash' declared here
  const std::vector<double> &getLineDash(double *start)
                             ^
1 error generated.
make: *** [xmloutputdev.o] Error 1
make: *** Waiting for unfinished jobs....
```

Upstream poppler commit change: https://gitlab.freedesktop.org/poppler/poppler/-/commit/c9c5eb782a8820f328dc32bcaf74d7f0b2cb6d7a