### PR TITLE
Update xmloutputdev.cpp

### DIFF
--- a/pdftoipe/xmloutputdev.cpp
+++ b/pdftoipe/xmloutputdev.cpp
@@ -220,7 +220,7 @@ void XmlOutputDev::doPath(GfxState *state)
 	++j;
       }
     }
-    if (subpath->isClosed()) {
+    if (subpath->isClosed() && m>1) {
       writePS("h\n");
     }
   }


### PR DESCRIPTION
When subpath has only one point, it should not be closed (even if requested) with the `writePS("h\n")` statement. Otherwise, Ipe will crash (due to assertion at ipeshape.cpp line 428.). The problem output is illustrated in the following Ipe generated by pdftoipe. The proposed change will remove the second `h` element, and hence make Ipe happy. 

<path stroke="0.000000 0.000000 0.000000" pen="0.8"> 233.392 619.464 m
428.788 619.464 l
428.788 453.707 l
233.392 453.707 l
233.392 619.464 l
h
428.788 619.464 m
h
</path>