### PR TITLE
pdftoipe transparency

### DIFF
--- a/pdftoipe/xmloutputdev.cpp
+++ b/pdftoipe/xmloutputdev.cpp
@@ -2,33 +2,32 @@
 // Output device writing XML stream
 // --------------------------------------------------------------------
 
-#include <stdio.h>
-#include <stddef.h>
 #include <stdarg.h>
+#include <stddef.h>
+#include <stdio.h>
 
 #include <string>
 
-#include "Object.h"
+#include "Catalog.h"
 #include "Error.h"
 #include "Gfx.h"
-#include "GfxState.h"
 #include "GfxFont.h"
-#include "Catalog.h"
+#include "GfxState.h"
+#include "Object.h"
 #include "Page.h"
 #include "Stream.h"
 
 #include "xmloutputdev.h"
 
+#include <cmath>
 #include <vector>
-#include <cmath> 
 
 //------------------------------------------------------------------------
 // XmlOutputDev
 //------------------------------------------------------------------------
 
-XmlOutputDev::XmlOutputDev(const std::string& fileName, XRef *xrefA, Catalog *catalog,
-                           int firstPage, int lastPage)
-{
+XmlOutputDev::XmlOutputDev(const std::string &fileName, XRef *xrefA,
+                           Catalog *catalog, int firstPage, int lastPage) {
   FILE *f;
 
   if (!(f = fopen(fileName.c_str(), "wb"))) {
@@ -45,7 +44,7 @@ XmlOutputDev::XmlOutputDev(const std::string& fileName, XRef *xrefA, Catalog *ca
   iUnicode = false;
 
   // set defaults
-  iIsMath = false; 
+  iIsMath = false;
   iNoText = false;
   iIsLiteral = false;
   iMergeLevel = 0;
@@ -68,20 +67,21 @@ XmlOutputDev::XmlOutputDev(const std::string& fileName, XRef *xrefA, Catalog *ca
   const PDFRectangle *media = page->getMediaBox();
   const PDFRectangle *crop = page->getCropBox();
 
-  fprintf(stderr, "MediaBox: %g %g %g %g (%g x %g)\n", 
-	  media->x1, media->x2, media->y1, media->y2, wid, ht);
-  fprintf(stderr, "CropBox: %g %g %g %g\n", 
-	  crop->x1, crop->x2, crop->y1, crop->y2);
+  fprintf(stderr, "MediaBox: %g %g %g %g (%g x %g)\n", media->x1, media->x2,
+          media->y1, media->y2, wid, ht);
+  fprintf(stderr, "CropBox: %g %g %g %g\n", crop->x1, crop->x2, crop->y1,
+          crop->y2);
 
   writePS("<?xml version=\"1.0\"?>\n");
   writePS("<!DOCTYPE ipe SYSTEM \"ipe.dtd\">\n");
-  writePSFmt("<ipe version=\"70000\" creator=\"pdftoipe %s\">\n", 
-	     PDFTOIPE_VERSION);
+  writePSFmt("<ipe version=\"70000\" creator=\"pdftoipe %s\">\n",
+             PDFTOIPE_VERSION);
   writePS("<ipestyle>\n");
-  writePSFmt("<layout paper=\"%g %g\" frame=\"%g %g\" origin=\"%g %g\"/>\n", 
-	     wid, ht, crop->x2 - crop->x1, crop->y2 - crop->y1, 
-	     crop->x1 - media->x1, crop->y1 - media->y1);
-  writePS("<symbol name=\"bullet\"><path matrix=\"0.04 0 0 0.04 0 0\" fill=\"black\">\n");
+  writePSFmt("<layout paper=\"%g %g\" frame=\"%g %g\" origin=\"%g %g\"/>\n",
+             wid, ht, crop->x2 - crop->x1, crop->y2 - crop->y1,
+             crop->x1 - media->x1, crop->y1 - media->y1);
+  writePS("<symbol name=\"bullet\"><path matrix=\"0.04 0 0 0.04 0 0\" "
+          "fill=\"black\">\n");
   writePS("18 0 0 18 0 0 e</path></symbol>\n");
   writePS("</ipestyle>\n");
 
@@ -89,8 +89,7 @@ XmlOutputDev::XmlOutputDev(const std::string& fileName, XRef *xrefA, Catalog *ca
   seqPage = 1;
 }
 
-XmlOutputDev::~XmlOutputDev()
-{
+XmlOutputDev::~XmlOutputDev() {
   if (ok) {
     finishText();
     writePS("</ipe>\n");
@@ -100,10 +99,9 @@ XmlOutputDev::~XmlOutputDev()
 
 // ----------------------------------------------------------
 
-void XmlOutputDev::setTextHandling(bool math, bool notext, 
-                                   bool literal, int mergeLevel,
-				   bool noTextSize, int unicodeLevel)
-{
+void XmlOutputDev::setTextHandling(bool math, bool notext, bool literal,
+                                   int mergeLevel, bool noTextSize,
+                                   int unicodeLevel) {
   iIsMath = math;
   iNoText = notext;
   iIsLiteral = literal;
@@ -119,30 +117,23 @@ void XmlOutputDev::setTextHandling(bool math, bool notext,
 
 // ----------------------------------------------------------
 
-void XmlOutputDev::startPage(int pageNum, GfxState *state, XRef *xrefA)
-{
+void XmlOutputDev::startPage(int pageNum, GfxState *state, XRef *xrefA) {
   writePSFmt("<!-- Page: %d %d -->\n", pageNum, seqPage);
-  fprintf(stderr, "Converting page %d (numbered %d)\n", 
-	  seqPage, pageNum);
+  fprintf(stderr, "Converting page %d (numbered %d)\n", seqPage, pageNum);
   writePS("<page>\n");
   ++seqPage;
 }
 
-void XmlOutputDev::endPage()
-{
+void XmlOutputDev::endPage() {
   finishText();
   writePS("</page>\n");
 }
 
 // --------------------------------------------------------------------
 
-void XmlOutputDev::startDrawingPath()
-{
-  finishText();
-}
+void XmlOutputDev::startDrawingPath() { finishText(); }
 
-void XmlOutputDev::stroke(GfxState *state)
-{
+void XmlOutputDev::stroke(GfxState *state) {
   startDrawingPath();
   GfxRGB rgb;
   state->getStrokeRGB(&rgb);
@@ -151,27 +142,27 @@ void XmlOutputDev::stroke(GfxState *state)
 
   double start;
   int length, i;
-  #if POPPLER_VERSION_AT_LEAST(22, 9, 0)
-    std::vector<double> dash = state->getLineDash(&start);
-    length = dash.size();
-  #else
-    double *dash;
-    state->getLineDash(&dash, &length, &start);
-  #endif
+#if POPPLER_VERSION_AT_LEAST(22, 9, 0)
+  std::vector<double> dash = state->getLineDash(&start);
+  length = dash.size();
+#else
+  double *dash;
+  state->getLineDash(&dash, &length, &start);
+#endif
 
   if (length) {
     writePS(" dash=\"[");
     for (i = 0; i < length; ++i)
-      #if POPPLER_VERSION_AT_LEAST(22, 9, 0)
+#if POPPLER_VERSION_AT_LEAST(22, 9, 0)
       writePSFmt("%g%s", state->transformWidth(dash.at(i)),
- 		 (i == length-1) ? "" : " ");
-      #else
+                 (i == length - 1) ? "" : " ");
+#else
       writePSFmt("%g%s", state->transformWidth(dash[i]),
                  (i == length - 1) ? "" : " ");
-      #endif
+#endif
     writePSFmt("] %g\"", state->transformWidth(start));
   }
-    
+
   if (state->getLineJoin() > 0)
     writePSFmt(" join=\"%d\"", state->getLineJoin());
   if (state->getLineCap())
@@ -182,8 +173,7 @@ void XmlOutputDev::stroke(GfxState *state)
   writePS("</path>\n");
 }
 
-void XmlOutputDev::fill(GfxState *state)
-{
+void XmlOutputDev::fill(GfxState *state) {
   startDrawingPath();
   GfxRGB rgb;
   state->getFillRGB(&rgb);
@@ -192,18 +182,16 @@ void XmlOutputDev::fill(GfxState *state)
   writePS("</path>\n");
 }
 
-void XmlOutputDev::eoFill(GfxState *state)
-{
+void XmlOutputDev::eoFill(GfxState *state) {
   startDrawingPath();
   GfxRGB rgb;
   state->getFillRGB(&rgb);
-  writeColor("<path fill=", rgb, ">\n"); 
+  writeColor("<path fill=", rgb, ">\n");
   doPath(state);
   writePS("</path>\n");
 }
 
-void XmlOutputDev::doPath(GfxState *state)
-{
+void XmlOutputDev::doPath(GfxState *state) {
   const GfxPath *path = state->getPath();
   const GfxSubpath *subpath;
   int n, m, i, j;
@@ -219,18 +207,18 @@ void XmlOutputDev::doPath(GfxState *state)
     j = 1;
     while (j < m) {
       if (subpath->getCurve(j)) {
-	state->transform(subpath->getX(j), subpath->getY(j), &x, &y);
-	state->transform(subpath->getX(j+1), subpath->getY(j+1), &x1, &y1);
-	state->transform(subpath->getX(j+2), subpath->getY(j+2), &x2, &y2);
-	writePSFmt("%g %g %g %g %g %g c\n", x, y, x1, y1, x2, y2);
-	j += 3;
+        state->transform(subpath->getX(j), subpath->getY(j), &x, &y);
+        state->transform(subpath->getX(j + 1), subpath->getY(j + 1), &x1, &y1);
+        state->transform(subpath->getX(j + 2), subpath->getY(j + 2), &x2, &y2);
+        writePSFmt("%g %g %g %g %g %g c\n", x, y, x1, y1, x2, y2);
+        j += 3;
       } else {
-	state->transform(subpath->getX(j), subpath->getY(j), &x, &y);
-	writePSFmt("%g %g l\n", x, y);
-	++j;
+        state->transform(subpath->getX(j), subpath->getY(j), &x, &y);
+        writePSFmt("%g %g l\n", x, y);
+        ++j;
       }
     }
-    if (subpath->isClosed() && m>1) {
+    if (subpath->isClosed() && m > 1) {
       writePS("h\n");
     }
   }
@@ -238,24 +226,20 @@ void XmlOutputDev::doPath(GfxState *state)
 
 // --------------------------------------------------------------------
 
-void XmlOutputDev::updateTextPos(GfxState *)
-{
+void XmlOutputDev::updateTextPos(GfxState *) {
   if (iMergeLevel < 2)
     finishText();
 }
 
-void XmlOutputDev::updateTextShift(GfxState *, double /*shift*/)
-{
+void XmlOutputDev::updateTextShift(GfxState *, double /*shift*/) {
   if (iMergeLevel < 1)
     finishText();
 }
 
-void XmlOutputDev::drawChar(GfxState *state, double x, double y,
-			    double dx, double dy,
-			    double originX, double originY,
-			    CharCode code, int nBytes, 
-			    const Unicode *u, int uLen)
-{
+void XmlOutputDev::drawChar(GfxState *state, double x, double y, double dx,
+                            double dy, double originX, double originY,
+                            CharCode code, int nBytes, const Unicode *u,
+                            int uLen) {
   // check for invisible text -- this is used by Acrobat Capture
   if ((state->getRender() & 3) == 3)
     return;
@@ -271,7 +255,7 @@ void XmlOutputDev::drawChar(GfxState *state, double x, double y,
 
   if (uLen == 0) {
     if (code == 0x62) {
-      // this is a hack to handle bullets created by pstricks and should 
+      // this is a hack to handle bullets created by pstricks and should
       // probably be an option
       writePS("\\ipesymbol{bullet}{}{}{}");
     } else
@@ -282,8 +266,7 @@ void XmlOutputDev::drawChar(GfxState *state, double x, double y,
   }
 }
 
-void XmlOutputDev::startText(GfxState *state, double x, double y)
-{
+void XmlOutputDev::startText(GfxState *state, double x, double y) {
   if (inText)
     return;
 
@@ -301,10 +284,10 @@ void XmlOutputDev::startText(GfxState *state, double x, double y)
 #endif
 
   /*
-  fprintf(stderr, "TextMatrix = %g %g %g %g %g %g\n", 
-	  Tp[0], Tp[1], Tp[2], Tp[3], Tp[4], Tp[5]);
-  fprintf(stderr, "CTM = %g %g %g %g %g %g\n", 
-	  Cp[0], Cp[1], Cp[2], Cp[3], Cp[4], Cp[5]);
+  fprintf(stderr, "TextMatrix = %g %g %g %g %g %g\n",
+          Tp[0], Tp[1], Tp[2], Tp[3], Tp[4], Tp[5]);
+  fprintf(stderr, "CTM = %g %g %g %g %g %g\n",
+          Cp[0], Cp[1], Cp[2], Cp[3], Cp[4], Cp[5]);
   */
 
   double M[4];
@@ -328,8 +311,7 @@ void XmlOutputDev::startText(GfxState *state, double x, double y)
   inText = true;
 }
 
-void XmlOutputDev::finishText()
-{
+void XmlOutputDev::finishText() {
   if (inText) {
     if (iIsMath)
       writePS("$");
@@ -342,9 +324,8 @@ void XmlOutputDev::finishText()
 
 void XmlOutputDev::drawImage(GfxState *state, Object *ref, Stream *str,
                              int width, int height, GfxImageColorMap *colorMap,
-                             bool interpolate, const int *maskColors, 
-                             bool inlineImg)
-{
+                             bool interpolate, const int *maskColors,
+                             bool inlineImg) {
   finishText();
 
   ImageStream *imgStr;
@@ -362,20 +343,20 @@ void XmlOutputDev::drawImage(GfxState *state, Object *ref, Stream *str,
 #else
   const double *mat = state->getCTM();
 #endif
-  writePSFmt(" rect=\"0 1 1 0\" matrix=\"%g %g %g %g %g %g\"",
-      mat[0], mat[1], mat[2], mat[3], mat[4], mat[5]);
-  
+  writePSFmt(" rect=\"0 1 1 0\" matrix=\"%g %g %g %g %g %g\"", mat[0], mat[1],
+             mat[2], mat[3], mat[4], mat[5]);
+
   if (str->getKind() == strDCT && !inlineImg &&
       3 <= colorMap->getNumPixelComps() && colorMap->getNumPixelComps() <= 4) {
     // dump JPEG stream
     std::vector<char> buffer;
     // initialize stream
     str = str->getNextStream();
-  #if POPPLER_VERSION_AT_LEAST(26, 1, 0)
+#if POPPLER_VERSION_AT_LEAST(26, 1, 0)
     str->rewind();
-  #else
+#else
     str->reset();
-  #endif
+#endif
     // copy the stream
     while ((c = str->getChar()) != EOF)
       buffer.push_back(char(c));
@@ -383,13 +364,13 @@ void XmlOutputDev::drawImage(GfxState *state, Object *ref, Stream *str,
 
     if (colorMap->getNumPixelComps() == 3)
       writePS(" ColorSpace=\"DeviceRGB\"");
-    else 
+    else
       writePS(" ColorSpace=\"DeviceCMYK\"");
     writePS(" BitsPerComponent=\"8\"");
     writePS(" Filter=\"DCTDecode\"");
     writePSFmt(" length=\"%d\"", buffer.size());
     writePS(">\n");
-    
+
     for (unsigned int i = 0; i < buffer.size(); ++i)
       writePSFmt("%02x", buffer[i] & 0xff);
 
@@ -398,11 +379,11 @@ void XmlOutputDev::drawImage(GfxState *state, Object *ref, Stream *str,
     // 1 bit depth -- not implemented in Ipe
 
     // initialize stream
-  #if POPPLER_VERSION_AT_LEAST(26, 1, 0)
+#if POPPLER_VERSION_AT_LEAST(26, 1, 0)
     str->rewind();
-  #else
+#else
     str->reset();
-  #endif
+#endif
     // copy the stream
     size = height * ((width + 7) / 8);
     for (i = 0; i < size; ++i) {
@@ -415,26 +396,26 @@ void XmlOutputDev::drawImage(GfxState *state, Object *ref, Stream *str,
     writePS(" ColorSpace=\"DeviceGray\"");
     writePS(" BitsPerComponent=\"8\"");
     writePS(">\n");
-    
+
     // initialize stream
     imgStr = new ImageStream(str, width, colorMap->getNumPixelComps(),
-			     colorMap->getBits());
-  #if POPPLER_VERSION_AT_LEAST(26, 1, 0)
+                             colorMap->getBits());
+#if POPPLER_VERSION_AT_LEAST(26, 1, 0)
     imgStr->rewind();
-  #else
+#else
     imgStr->reset();
-  #endif
-    
+#endif
+
     // for each line...
     for (y = 0; y < height; ++y) {
-      
+
       // write the line
       p = imgStr->getLine();
       for (x = 0; x < width; ++x) {
-	GfxGray gray;
-	colorMap->getGray(p, &gray);
-	writePSFmt("%02x", colToByte(gray));
-	p += colorMap->getNumPixelComps();
+        GfxGray gray;
+        colorMap->getGray(p, &gray);
+        writePSFmt("%02x", colToByte(gray));
+        p += colorMap->getNumPixelComps();
       }
     }
     delete imgStr;
@@ -444,26 +425,26 @@ void XmlOutputDev::drawImage(GfxState *state, Object *ref, Stream *str,
     writePS(" ColorSpace=\"DeviceRGB\"");
     writePS(" BitsPerComponent=\"8\"");
     writePS(">\n");
-    
+
     // initialize stream
     imgStr = new ImageStream(str, width, colorMap->getNumPixelComps(),
-			     colorMap->getBits());
-  #if POPPLER_VERSION_AT_LEAST(26, 1, 0)
+                             colorMap->getBits());
+#if POPPLER_VERSION_AT_LEAST(26, 1, 0)
     imgStr->rewind();
-  #else
+#else
     imgStr->reset();
-  #endif
-    
+#endif
+
     // for each line...
     for (y = 0; y < height; ++y) {
-      
+
       // write the line
       p = imgStr->getLine();
       for (x = 0; x < width; ++x) {
-	colorMap->getRGB(p, &rgb);
-	writePSFmt("%02x%02x%02x", 
-		   colToByte(rgb.r), colToByte(rgb.g), colToByte(rgb.b));
-	p += colorMap->getNumPixelComps();
+        colorMap->getRGB(p, &rgb);
+        writePSFmt("%02x%02x%02x", colToByte(rgb.r), colToByte(rgb.g),
+                   colToByte(rgb.b));
+        p += colorMap->getNumPixelComps();
       }
     }
     delete imgStr;
@@ -471,26 +452,25 @@ void XmlOutputDev::drawImage(GfxState *state, Object *ref, Stream *str,
   writePS("\n</image>\n");
 }
 
-void XmlOutputDev::drawSoftMaskedImage(
-    GfxState *state, Object *ref,
-    Stream *str, int width, int height,
-    GfxImageColorMap *colorMap,
-    bool interpolate, Stream *maskStr,
-    int maskWidth, int maskHeight,
-    GfxImageColorMap *maskColorMap,
-    bool maskInterpolate)
-{
+void XmlOutputDev::drawSoftMaskedImage(GfxState *state, Object *ref,
+                                       Stream *str, int width, int height,
+                                       GfxImageColorMap *colorMap,
+                                       bool interpolate, Stream *maskStr,
+                                       int maskWidth, int maskHeight,
+                                       GfxImageColorMap *maskColorMap,
+                                       bool maskInterpolate) {
   finishText();
 
   ImageStream *imgStr;
   const double *mat = state->getCTM();
 
   writePSFmt("<image width=\"%d\" height=\"%d\"", width, height);
-  writePSFmt(" rect=\"0 1 1 0\" matrix=\"%g %g %g %g %g %g\"",
-             mat[0], mat[1], mat[2], mat[3], mat[4], mat[5]);
+  writePSFmt(" rect=\"0 1 1 0\" matrix=\"%g %g %g %g %g %g\"", mat[0], mat[1],
+             mat[2], mat[3], mat[4], mat[5]);
 
   bool maskOpaque = true;
-  imgStr = new ImageStream(maskStr, maskWidth, maskColorMap->getNumPixelComps(), maskColorMap->getBits());
+  imgStr = new ImageStream(maskStr, maskWidth, maskColorMap->getNumPixelComps(),
+                           maskColorMap->getBits());
   imgStr->reset();
 
   for (int y = 0; y < maskHeight; ++y) {
@@ -508,7 +488,8 @@ void XmlOutputDev::drawSoftMaskedImage(
 escapeMask:
 
   bool grayImage = true;
-  imgStr = new ImageStream(str, width, colorMap->getNumPixelComps(), colorMap->getBits());
+  imgStr = new ImageStream(str, width, colorMap->getNumPixelComps(),
+                           colorMap->getBits());
   imgStr->reset();
 
   for (int y = 0; y < height; ++y) {
@@ -563,9 +544,7 @@ escapeGray:
       for (int x = 0; x < width; ++x) {
         GfxRGB rgb;
         colorMap->getRGB(p, &rgb);
-        writePSFmt("%02x%02x%02x",
-                   colToByte(rgb.r),
-                   colToByte(rgb.g),
+        writePSFmt("%02x%02x%02x", colToByte(rgb.r), colToByte(rgb.g),
                    colToByte(rgb.b));
         p += colorMap->getNumPixelComps();
       }
@@ -574,7 +553,9 @@ escapeGray:
 
   // Alpha mask
   {
-    imgStr = new ImageStream(maskStr, maskWidth, maskColorMap->getNumPixelComps(), maskColorMap->getBits());
+    imgStr =
+        new ImageStream(maskStr, maskWidth, maskColorMap->getNumPixelComps(),
+                        maskColorMap->getBits());
     imgStr->reset();
 
     for (int y = 0; y < maskHeight; ++y) {
@@ -599,100 +580,99 @@ struct UnicodeToLatex {
 };
 
 static const UnicodeToLatex unicode2latex[] = {
-  // { 0xed, "{\\'\\i}" },
-  // --------------------------------------------------------------------
-  { 0xb1,  "$\\pm$" },
-  { 0x391, "$\\Alpha$" },
-  { 0x392, "$\\Beta$" },
-  { 0x393, "$\\Gamma$" },
-  { 0x394, "$\\Delta$" },
-  { 0x395, "$\\Epsilon$" },
-  { 0x396, "$\\Zeta$" },
-  { 0x397, "$\\Eta$" },
-  { 0x398, "$\\Theta$" },
-  { 0x399, "$\\Iota$" },
-  { 0x39a, "$\\Kappa$" },
-  { 0x39b, "$\\Lambda$" },
-  { 0x39c, "$\\Mu$" },
-  { 0x39e, "$\\Nu$" },
-  { 0x39e, "$\\Xi$" },
-  { 0x39f, "$\\Omicron$" },
-  { 0x3a0, "$\\Pi$" },
-  { 0x3a1, "$\\Rho$" },
-  { 0x3a3, "$\\Sigma$" },   // sometimes \\sum would be better
-  { 0x3a4, "$\\Tau$" },
-  { 0x3a5, "$\\Upsilon$" },
-  { 0x3a6, "$\\Phi$" },
-  { 0x3a7, "$\\Chi$" },
-  { 0x3a8, "$\\Psi$" },
-  { 0x3a9, "$\\Omega$" },
-  // --------------------------------------------------------------------
-  { 0x3b1, "$\\alpha$" },
-  { 0x3b2, "$\\beta$" },
-  { 0x3b3, "$\\gamma$" },
-  { 0x3b4, "$\\delta$" },
-  { 0x3b5, "$\\varepsilon$" },
-  { 0x3b6, "$\\zeta$" },
-  { 0x3b7, "$\\eta$" },
-  { 0x3b8, "$\\theta$" },
-  { 0x3b9, "$\\iota$" },
-  { 0x3ba, "$\\kappa$" },
-  { 0x3bb, "$\\lambda$" },
-  { 0x3bc, "$\\mu$" },
-  { 0x3be, "$\\nu$" },
-  { 0x3be, "$\\xi$" },
-  { 0x3bf, "$\\omicron$" },
-  { 0x3c0, "$\\pi$" },
-  { 0x3c1, "$\\rho$" },
-  { 0x3c3, "$\\sigma$" },
-  { 0x3c4, "$\\tau$" },
-  { 0x3c5, "$\\upsilon$" },
-  { 0x3c6, "$\\phi$" },
-  { 0x3c7, "$\\chi$" },
-  { 0x3c8, "$\\psi$" },
-  { 0x3c9, "$\\omega$" },
-  // --------------------------------------------------------------------
-  { 0x2013, "-" },
-  { 0x2019, "'" },
-  { 0x2022, "$\\bullet$" },
-  { 0x2026, "$\\cdots$" },
-  { 0x2190, "$\\leftarrow$" },
-  { 0x21d2, "$\\Rightarrow$" },
-  { 0x2208, "$\\in$" },
-  { 0x2209, "$\\not\\in$" },
-  { 0x2211, "$\\sum$" },
-  { 0x2212, "-" },
-  { 0x221e, "$\\infty$" },
-  { 0x222a, "$\\cup$" },
-  { 0x2260, "$\\neq$" },
-  { 0x2264, "$\\leq$" },
-  { 0x2265, "$\\geq$" },
-  { 0x22c5, "$\\cdot$" },
-  { 0x2286, "$\\subseteq$" },
-  { 0x25aa, "$\\diamondsuit$" },
-  // --------------------------------------------------------------------
-  // ligatures
-  { 0xfb00, "ff" },
-  { 0xfb01, "fi" },
-  { 0xfb02, "fl" },
-  { 0xfb03, "ffi" },
-  { 0xfb04, "ffl" },
-  { 0xfb06, "st" },
-  // --------------------------------------------------------------------
+    // { 0xed, "{\\'\\i}" },
+    // --------------------------------------------------------------------
+    {0xb1, "$\\pm$"},
+    {0x391, "$\\Alpha$"},
+    {0x392, "$\\Beta$"},
+    {0x393, "$\\Gamma$"},
+    {0x394, "$\\Delta$"},
+    {0x395, "$\\Epsilon$"},
+    {0x396, "$\\Zeta$"},
+    {0x397, "$\\Eta$"},
+    {0x398, "$\\Theta$"},
+    {0x399, "$\\Iota$"},
+    {0x39a, "$\\Kappa$"},
+    {0x39b, "$\\Lambda$"},
+    {0x39c, "$\\Mu$"},
+    {0x39e, "$\\Nu$"},
+    {0x39e, "$\\Xi$"},
+    {0x39f, "$\\Omicron$"},
+    {0x3a0, "$\\Pi$"},
+    {0x3a1, "$\\Rho$"},
+    {0x3a3, "$\\Sigma$"}, // sometimes \\sum would be better
+    {0x3a4, "$\\Tau$"},
+    {0x3a5, "$\\Upsilon$"},
+    {0x3a6, "$\\Phi$"},
+    {0x3a7, "$\\Chi$"},
+    {0x3a8, "$\\Psi$"},
+    {0x3a9, "$\\Omega$"},
+    // --------------------------------------------------------------------
+    {0x3b1, "$\\alpha$"},
+    {0x3b2, "$\\beta$"},
+    {0x3b3, "$\\gamma$"},
+    {0x3b4, "$\\delta$"},
+    {0x3b5, "$\\varepsilon$"},
+    {0x3b6, "$\\zeta$"},
+    {0x3b7, "$\\eta$"},
+    {0x3b8, "$\\theta$"},
+    {0x3b9, "$\\iota$"},
+    {0x3ba, "$\\kappa$"},
+    {0x3bb, "$\\lambda$"},
+    {0x3bc, "$\\mu$"},
+    {0x3be, "$\\nu$"},
+    {0x3be, "$\\xi$"},
+    {0x3bf, "$\\omicron$"},
+    {0x3c0, "$\\pi$"},
+    {0x3c1, "$\\rho$"},
+    {0x3c3, "$\\sigma$"},
+    {0x3c4, "$\\tau$"},
+    {0x3c5, "$\\upsilon$"},
+    {0x3c6, "$\\phi$"},
+    {0x3c7, "$\\chi$"},
+    {0x3c8, "$\\psi$"},
+    {0x3c9, "$\\omega$"},
+    // --------------------------------------------------------------------
+    {0x2013, "-"},
+    {0x2019, "'"},
+    {0x2022, "$\\bullet$"},
+    {0x2026, "$\\cdots$"},
+    {0x2190, "$\\leftarrow$"},
+    {0x21d2, "$\\Rightarrow$"},
+    {0x2208, "$\\in$"},
+    {0x2209, "$\\not\\in$"},
+    {0x2211, "$\\sum$"},
+    {0x2212, "-"},
+    {0x221e, "$\\infty$"},
+    {0x222a, "$\\cup$"},
+    {0x2260, "$\\neq$"},
+    {0x2264, "$\\leq$"},
+    {0x2265, "$\\geq$"},
+    {0x22c5, "$\\cdot$"},
+    {0x2286, "$\\subseteq$"},
+    {0x25aa, "$\\diamondsuit$"},
+    // --------------------------------------------------------------------
+    // ligatures
+    {0xfb00, "ff"},
+    {0xfb01, "fi"},
+    {0xfb02, "fl"},
+    {0xfb03, "ffi"},
+    {0xfb04, "ffl"},
+    {0xfb06, "st"},
+    // --------------------------------------------------------------------
 };
 
 #define UNICODE2LATEX_LEN (sizeof(unicode2latex) / sizeof(UnicodeToLatex))
-    
-void XmlOutputDev::writePSUnicode(int ch)
-{
-  if (iIsLiteral  &&  ch == '\\') {
+
+void XmlOutputDev::writePSUnicode(int ch) {
+  if (iIsLiteral && ch == '\\') {
     writePSChar(ch);
     return;
   }
 
   if (!iIsLiteral) {
-    if (ch == '&' || ch == '$' || ch == '#' || ch == '%'
-	|| ch == '_' || ch == '{' || ch == '}') {
+    if (ch == '&' || ch == '$' || ch == '#' || ch == '%' || ch == '_' ||
+        ch == '{' || ch == '}') {
       writePS("\\");
       writePSChar(ch);
       return;
@@ -723,17 +703,16 @@ void XmlOutputDev::writePSUnicode(int ch)
   if (1 <= iUnicodeLevel && iUnicodeLevel <= 2) {
     for (int i = 0; i < UNICODE2LATEX_LEN; ++i) {
       if (ch == unicode2latex[i].iUnicode) {
-	writePS(unicode2latex[i].iLatex);
-	return;
+        writePS(unicode2latex[i].iLatex);
+        return;
       }
     }
   }
-  
+
   writePSChar(ch);
 }
 
-void XmlOutputDev::writePSChar(int code)
-{
+void XmlOutputDev::writePSChar(int code) {
   if (code == '<')
     writePS("&lt;");
   else if (code == '>')
@@ -746,27 +725,23 @@ void XmlOutputDev::writePSChar(int code)
     iUnicode = true;
     if (iUnicodeLevel < 2) {
       writePSFmt("[U+%x]", code);
-      fprintf(stderr, "Unknown Unicode character U+%x on page %d\n", 
-	      code, seqPage);
+      fprintf(stderr, "Unknown Unicode character U+%x on page %d\n", code,
+              seqPage);
     } else {
       if (code < 0x800) {
-	writePSFmt("%c%c", 
-		   (((code & 0x7c0) >> 6) | 0xc0),
-		   ((code & 0x03f) | 0x80)); 
+        writePSFmt("%c%c", (((code & 0x7c0) >> 6) | 0xc0),
+                   ((code & 0x03f) | 0x80));
       } else {
-	// Do we never need to write UCS larger than 0x10000?
-	writePSFmt("%c%c%c", 
-		   (((code & 0x0f000) >> 12) | 0xe0),
-		   (((code & 0xfc0) >> 6) | 0x80),
-		   ((code & 0x03f) | 0x80));
+        // Do we never need to write UCS larger than 0x10000?
+        writePSFmt("%c%c%c", (((code & 0x0f000) >> 12) | 0xe0),
+                   (((code & 0xfc0) >> 6) | 0x80), ((code & 0x03f) | 0x80));
       }
     }
   }
 }
 
-void XmlOutputDev::writeColor(const char *prefix, const GfxRGB &rgb, 
-			      const char *suffix)
-{
+void XmlOutputDev::writeColor(const char *prefix, const GfxRGB &rgb,
+                              const char *suffix) {
   if (prefix)
     writePS(prefix);
   writePSFmt("\"%f %f %f\"", colToDbl(rgb.r), colToDbl(rgb.g), colToDbl(rgb.b));
@@ -774,13 +749,11 @@ void XmlOutputDev::writeColor(const char *prefix, const GfxRGB &rgb,
     writePS(suffix);
 }
 
-void XmlOutputDev::writePS(const char *s)
-{
+void XmlOutputDev::writePS(const char *s) {
   fwrite(s, 1, strlen(s), outputStream);
 }
 
-void XmlOutputDev::writePSFmt(const char *fmt, ...)
-{
+void XmlOutputDev::writePSFmt(const char *fmt, ...) {
   va_list args;
   char buf[512];
 

--- a/pdftoipe/xmloutputdev.cpp
+++ b/pdftoipe/xmloutputdev.cpp
@@ -471,6 +471,126 @@ void XmlOutputDev::drawImage(GfxState *state, Object *ref, Stream *str,
   writePS("\n</image>\n");
 }
 
+void XmlOutputDev::drawSoftMaskedImage(
+    GfxState *state, Object *ref,
+    Stream *str, int width, int height,
+    GfxImageColorMap *colorMap,
+    bool interpolate, Stream *maskStr,
+    int maskWidth, int maskHeight,
+    GfxImageColorMap *maskColorMap,
+    bool maskInterpolate)
+{
+  finishText();
+
+  ImageStream *imgStr;
+  const double *mat = state->getCTM();
+
+  writePSFmt("<image width=\"%d\" height=\"%d\"", width, height);
+  writePSFmt(" rect=\"0 1 1 0\" matrix=\"%g %g %g %g %g %g\"",
+             mat[0], mat[1], mat[2], mat[3], mat[4], mat[5]);
+
+  bool maskOpaque = true;
+  imgStr = new ImageStream(maskStr, maskWidth, maskColorMap->getNumPixelComps(), maskColorMap->getBits());
+  imgStr->reset();
+
+  for (int y = 0; y < maskHeight; ++y) {
+    unsigned char *p = imgStr->getLine();
+    for (int x = 0; x < maskWidth; ++x) {
+      GfxGray gray;
+      maskColorMap->getGray(p, &gray);
+      if (colToByte(gray) != 255) {
+        maskOpaque = false;
+        goto escapeMask;
+      }
+      p += maskColorMap->getNumPixelComps();
+    }
+  }
+escapeMask:
+
+  bool grayImage = true;
+  imgStr = new ImageStream(str, width, colorMap->getNumPixelComps(), colorMap->getBits());
+  imgStr->reset();
+
+  for (int y = 0; y < height; ++y) {
+    unsigned char *p = imgStr->getLine();
+    for (int x = 0; x < width; ++x) {
+      GfxRGB rgb;
+      colorMap->getRGB(p, &rgb);
+      if (!(rgb.r == rgb.g && rgb.g == rgb.b)) {
+        grayImage = false;
+        goto escapeGray;
+      }
+      p += colorMap->getNumPixelComps();
+    }
+  }
+escapeGray:
+
+  // no mask for gray
+  if (grayImage) {
+    writePS(" ColorSpace=\"DeviceGray\"");
+    writePS(" BitsPerComponent=\"8\"");
+    writePS(">\n");
+
+    imgStr->reset();
+
+    for (int y = 0; y < height; ++y) {
+      unsigned char *p = imgStr->getLine();
+      for (int x = 0; x < width; ++x) {
+        GfxGray gray;
+        colorMap->getGray(p, &gray);
+        writePSFmt("%02x", colToByte(gray));
+        p += colorMap->getNumPixelComps();
+      }
+    }
+
+    writePS("\n</image>\n");
+    return;
+  }
+
+  // RGB
+  writePS(" ColorSpace=\"DeviceRGBAlpha\"");
+  writePS(" BitsPerComponent=\"8\"");
+  writePSFmt(" length=\"%d\"", width * height * 3);
+  writePSFmt(" alphaLength=\"%d\"", maskWidth * maskHeight);
+  writePS(">\n");
+
+  // RGB data
+  {
+    imgStr->reset();
+
+    for (int y = 0; y < height; ++y) {
+      unsigned char *p = imgStr->getLine();
+      for (int x = 0; x < width; ++x) {
+        GfxRGB rgb;
+        colorMap->getRGB(p, &rgb);
+        writePSFmt("%02x%02x%02x",
+                   colToByte(rgb.r),
+                   colToByte(rgb.g),
+                   colToByte(rgb.b));
+        p += colorMap->getNumPixelComps();
+      }
+    }
+  }
+
+  // Alpha mask
+  {
+    imgStr = new ImageStream(maskStr, maskWidth, maskColorMap->getNumPixelComps(), maskColorMap->getBits());
+    imgStr->reset();
+
+    for (int y = 0; y < maskHeight; ++y) {
+      unsigned char *p = imgStr->getLine();
+      for (int x = 0; x < maskWidth; ++x) {
+        GfxGray gray;
+        maskColorMap->getGray(p, &gray);
+        writePSFmt("%02x", colToByte(gray));
+        p += maskColorMap->getNumPixelComps();
+      }
+    }
+  }
+
+  writePS("\n</image>\n");
+}
+
 // --------------------------------------------------------------------
 
 struct UnicodeToLatex {

--- a/pdftoipe/xmloutputdev.h
+++ b/pdftoipe/xmloutputdev.h
@@ -81,6 +81,14 @@ public:
   virtual void drawImage(GfxState *state, Object *ref, Stream *str,
 			 int width, int height, GfxImageColorMap *colorMap,
 			 bool interpolate, const int *maskColors, bool inlineImg) override;
+  virtual void drawSoftMaskedImage(GfxState *state, Object *ref, Stream *str,
+			 int width, int height,
+			 GfxImageColorMap *colorMap, bool interpolate,
+			 Stream *maskStr, int maskWidth,
+			 int maskHeight,
+			 GfxImageColorMap *maskColorMap,
+			 bool maskInterpolate) override;
+
 
 protected:
   void startDrawingPath();

--- a/pdftoipe/xmloutputdev.h
+++ b/pdftoipe/xmloutputdev.h
@@ -6,30 +6,29 @@
 #ifndef XMLOUTPUTDEV_H
 #define XMLOUTPUTDEV_H
 
-#include <stddef.h>
+#include "GfxState.h"
 #include "Object.h"
 #include "OutputDev.h"
-#include "GfxState.h"
 #include "cpp/poppler-version.h"
+#include <stddef.h>
 
 class GfxPath;
 class GfxFont;
 
 #define PDFTOIPE_VERSION "2024/11/15"
 
-#define POPPLER_VERSION_AT_LEAST(major, minor, micro) \
-  ((POPPLER_VERSION_MAJOR > (major)) || \
-  (POPPLER_VERSION_MAJOR == (major) && POPPLER_VERSION_MINOR > (minor)) || \
-  (POPPLER_VERSION_MAJOR == (major) && POPPLER_VERSION_MINOR == (minor) && POPPLER_VERSION_MICRO >= (micro)))
+#define POPPLER_VERSION_AT_LEAST(major, minor, micro)                          \
+  ((POPPLER_VERSION_MAJOR > (major)) ||                                        \
+   (POPPLER_VERSION_MAJOR == (major) && POPPLER_VERSION_MINOR > (minor)) ||    \
+   (POPPLER_VERSION_MAJOR == (major) && POPPLER_VERSION_MINOR == (minor) &&    \
+    POPPLER_VERSION_MICRO >= (micro)))
 
-class XmlOutputDev : public OutputDev
-{
+class XmlOutputDev : public OutputDev {
 public:
-
   // Open an XML output file, and write the prolog.
-  XmlOutputDev(const std::string& fileName, XRef *xrefA, Catalog *catalog,
+  XmlOutputDev(const std::string &fileName, XRef *xrefA, Catalog *catalog,
                int firstPage, int lastPage);
-  
+
   // Destructor -- writes the trailer and closes the file.
   virtual ~XmlOutputDev();
 
@@ -38,9 +37,9 @@ public:
 
   bool hasUnicode() const { return iUnicode; }
 
-  void setTextHandling(bool math, bool notext, bool literal,
-                       int mergeLevel, bool noTextSize, int unicodeLevel);
-  
+  void setTextHandling(bool math, bool notext, bool literal, int mergeLevel,
+                       bool noTextSize, int unicodeLevel);
+
   //---- get info about output device
 
   // Does this device use upside-down coordinates?
@@ -72,30 +71,30 @@ public:
   virtual void eoFill(GfxState *state) override;
 
   //----- text drawing
-  virtual void drawChar(GfxState *state, double x, double y,
-			double dx, double dy,
-			double originX, double originY,
-			CharCode code, int nBytes, const Unicode *u, int uLen) override;
+  virtual void drawChar(GfxState *state, double x, double y, double dx,
+                        double dy, double originX, double originY,
+                        CharCode code, int nBytes, const Unicode *u,
+                        int uLen) override;
 
   //----- image drawing
-  virtual void drawImage(GfxState *state, Object *ref, Stream *str,
-			 int width, int height, GfxImageColorMap *colorMap,
-			 bool interpolate, const int *maskColors, bool inlineImg) override;
+  virtual void drawImage(GfxState *state, Object *ref, Stream *str, int width,
+                         int height, GfxImageColorMap *colorMap,
+                         bool interpolate, const int *maskColors,
+                         bool inlineImg) override;
   virtual void drawSoftMaskedImage(GfxState *state, Object *ref, Stream *str,
-			 int width, int height,
-			 GfxImageColorMap *colorMap, bool interpolate,
-			 Stream *maskStr, int maskWidth,
-			 int maskHeight,
-			 GfxImageColorMap *maskColorMap,
-			 bool maskInterpolate) override;
-
+                                   int width, int height,
+                                   GfxImageColorMap *colorMap, bool interpolate,
+                                   Stream *maskStr, int maskWidth,
+                                   int maskHeight,
+                                   GfxImageColorMap *maskColorMap,
+                                   bool maskInterpolate) override;
 
 protected:
   void startDrawingPath();
   void startText(GfxState *state, double x, double y);
   void finishText();
   void writePSUnicode(int ch);
-  
+
   void doPath(GfxState *state);
   void writePSChar(int code);
   void writePS(const char *s);
@@ -104,18 +103,18 @@ protected:
 
 protected:
   FILE *outputStream;
-  int seqPage;			// current sequential page number
-  XRef *xref;			// the xref table for this PDF file
-  bool ok;			    // set up ok?
-  bool iUnicode;                // has a Unicode character been used?
+  int seqPage;   // current sequential page number
+  XRef *xref;    // the xref table for this PDF file
+  bool ok;       // set up ok?
+  bool iUnicode; // has a Unicode character been used?
 
-  bool iIsLiteral;              // take latex in text literally
-  bool iIsMath;                 // make text objects math formulas
-  bool iNoText;                 // discard text objects
-  bool inText;                  // inside a text object
-  bool iNoTextSize;             // all text objects at normal size
-  int  iMergeLevel;             // text merge level
-  int iUnicodeLevel;            // unicode handling
+  bool iIsLiteral;   // take latex in text literally
+  bool iIsMath;      // make text objects math formulas
+  bool iNoText;      // discard text objects
+  bool inText;       // inside a text object
+  bool iNoTextSize;  // all text objects at normal size
+  int iMergeLevel;   // text merge level
+  int iUnicodeLevel; // unicode handling
 };
 
 // --------------------------------------------------------------------


### PR DESCRIPTION
Add support for image transparency in pdftoipe.

Before:
<img width="1349" height="647" alt="ex1" src="https://github.com/user-attachments/assets/79c849d8-8bc0-4744-aadc-2621691ad9cd" />
After:
<img width="1349" height="647" alt="ex2" src="https://github.com/user-attachments/assets/6ab62291-0301-4268-b604-1fd2c0ee255f" />

Actual changes are in 9053569a258d171b3faca884cdd7cede011e04d7
I also passed xmloutputdev.cpp and xmloutputdev.h to clang-format in ee45481fef00f39486cb404a718d73dc5f41ba57 because of mixed indentation and style inconsistencies in the files... Feel free to discard the commit if you don't want it.
