### PR TITLE
pdftoipe: Fix build on poppler 26.06

### DIFF
--- a/pdftoipe/xmloutputdev.cpp
+++ b/pdftoipe/xmloutputdev.cpp
@@ -64,8 +64,13 @@ XmlOutputDev::XmlOutputDev(const std::string &fileName, XRef *xrefA,
   }
   */
 
+#if POPPLER_VERSION_AT_LEAST(26, 6, 0)
+  const PDFRectangle *media = &page->getMediaBox();
+  const PDFRectangle *crop = &page->getCropBox();
+#else
   const PDFRectangle *media = page->getMediaBox();
   const PDFRectangle *crop = page->getCropBox();
+#endif
 
   fprintf(stderr, "MediaBox: %g %g %g %g (%g x %g)\n", media->x1, media->x2,
           media->y1, media->y2, wid, ht);


### PR DESCRIPTION
poppler 26.06 changed Page::getMediaBox()/getCropBox() to return a const reference instead of a pointer. Guard with POPPLER_VERSION_AT_LEAST so the code keeps building against both older and newer poppler.